### PR TITLE
Support multilabel split, preserving class distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-Simple tool to split coco annotations (json) into train and test sets.
+Simple tool to split a multi-label coco annotation dataset with preserving class distributions among train and test sets.
+
+The code is an updated version from akarazniewicz/cocosplit original repo, where the functionality of splitting multi-class data while preserving distributions is added.
+
 
 ## Installation
 
@@ -9,6 +12,9 @@ pip install -r requirements
 ```
 
 ## Usage
+
+The same as the original repo, with adding an argument (``--multi-class``) to preserve class distributions
+The argument is optional to ensure backward compatibility
 
 ```
 $ python cocosplit.py -h
@@ -27,12 +33,14 @@ optional arguments:
   -s SPLIT              A percentage of a split; a number in (0, 1)
   --having-annotations  Ignore all images without annotations. Keep only these
                         with at least one annotation
+  --multi-class         Split a multi-class dataset while preserving class
+                        distributions in train and test sets
 ```
 
 # Running
 
 ```
-$ python cocosplit.py --having-annotations -s 0.8 /path/to/your/coco_annotations.json train.json test.json
+$ python cocosplit.py --having-annotations --multi-class -s 0.8 /path/to/your/coco_annotations.json train.json test.json
 ```
 
 will split ``coco_annotation.json`` into ``train.json`` and ``test.json`` with ratio 80%/20% respectively. It will skip all

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Simple tool to split a multi-label coco annotation dataset with preserving class distributions among train and test sets.
 
-The code is an updated version from akarazniewicz/cocosplit original repo, where the functionality of splitting multi-class data while preserving distributions is added.
+The code is an updated version from [akarazniewicz/cocosplit](https://github.com/akarazniewicz/cocosplit)  original repo, where the functionality of splitting multi-class data while preserving distributions is added.
 
 
 ## Installation

--- a/cocosplit.py
+++ b/cocosplit.py
@@ -2,6 +2,26 @@ import json
 import argparse
 import funcy
 from sklearn.model_selection import train_test_split
+from skmultilearn.model_selection import iterative_train_test_split
+import numpy as np
+
+
+def save_coco(file, info, licenses, images, annotations, categories):
+    with open(file, 'wt', encoding='UTF-8') as coco:
+        json.dump({ 'info': info, 'licenses': licenses, 'images': images, 
+            'annotations': annotations, 'categories': categories}, coco, indent=2, sort_keys=True)
+
+def filter_annotations(annotations, images):
+    image_ids = funcy.lmap(lambda i: int(i['id']), images)
+    return funcy.lfilter(lambda a: int(a['image_id']) in image_ids, annotations)
+
+
+def filter_images(images, annotations):
+
+    annotation_ids = funcy.lmap(lambda i: int(i['image_id']), annotations)
+
+    return funcy.lfilter(lambda a: int(a['id']) in annotation_ids, images)
+
 
 parser = argparse.ArgumentParser(description='Splits COCO annotations file into training and test sets.')
 parser.add_argument('annotations', metavar='coco_annotations', type=str,
@@ -13,18 +33,13 @@ parser.add_argument('-s', dest='split', type=float, required=True,
 parser.add_argument('--having-annotations', dest='having_annotations', action='store_true',
                     help='Ignore all images without annotations. Keep only these with at least one annotation')
 
+parser.add_argument('--multi-class', dest='multi_class', action='store_true',
+                    help='Split a multi-class dataset while preserving class distributions in train and test sets')
+
 args = parser.parse_args()
 
-def save_coco(file, info, licenses, images, annotations, categories):
-    with open(file, 'wt', encoding='UTF-8') as coco:
-        json.dump({ 'info': info, 'licenses': licenses, 'images': images, 
-            'annotations': annotations, 'categories': categories}, coco, indent=2, sort_keys=True)
-
-def filter_annotations(annotations, images):
-    image_ids = funcy.lmap(lambda i: int(i['id']), images)
-    return funcy.lfilter(lambda a: int(a['image_id']) in image_ids, annotations)
-
 def main(args):
+
     with open(args.annotations, 'rt', encoding='UTF-8') as annotations:
         coco = json.load(annotations)
         info = coco['info']
@@ -40,12 +55,37 @@ def main(args):
         if args.having_annotations:
             images = funcy.lremove(lambda i: i['id'] not in images_with_annotations, images)
 
-        x, y = train_test_split(images, train_size=args.split)
 
-        save_coco(args.train, info, licenses, x, filter_annotations(annotations, x), categories)
-        save_coco(args.test, info, licenses, y, filter_annotations(annotations, y), categories)
+        if args.multi_class:
 
-        print("Saved {} entries in {} and {} in {}".format(len(x), args.train, len(y), args.test))
+            annotation_categories = funcy.lmap(lambda a: int(a['category_id']), annotations)
+
+            #bottle neck 1
+            #remove classes that has only one sample, because it can't be split into the training and testing sets
+            annotation_categories =  funcy.lremove(lambda i: annotation_categories.count(i) <=1  , annotation_categories)
+
+            annotations =  funcy.lremove(lambda i: i['category_id'] not in annotation_categories  , annotations)
+
+
+            X_train, y_train, X_test, y_test = iterative_train_test_split(np.array([annotations]).T,np.array([ annotation_categories]).T, test_size = 1-args.split)
+
+            save_coco(args.train, info, licenses, filter_images(images, X_train.reshape(-1)), X_train.reshape(-1).tolist(), categories)
+            save_coco(args.test, info, licenses,  filter_images(images, X_test.reshape(-1)), X_test.reshape(-1).tolist(), categories)
+
+            print("Saved {} entries in {} and {} in {}".format(len(X_train), args.train, len(X_test), args.test))
+            
+        else:
+
+            X_train, X_test = train_test_split(images, train_size=args.split)
+
+            anns_train = filter_annotations(annotations, X_train)
+            anns_test=filter_annotations(annotations, X_test)
+
+            save_coco(args.train, info, licenses, X_train, anns_train, categories)
+            save_coco(args.test, info, licenses, X_test, anns_test, categories)
+
+            print("Saved {} entries in {} and {} in {}".format(len(anns_train), args.train, len(anns_test), args.test))
+            
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sklearn
 funcy
 argparse
+scikit-multilearn


### PR DESCRIPTION
An update to support splitting multiclass coco dataset while keeping class distributions with the same train/test split ratio. The update ensures backward compatibility