### PR TITLE
'info' and 'licenses' not necessary in the COCO file + New order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Simple tool to split a multi-label coco annotation dataset with preserving class distributions among train and test sets.
 
-The code is an updated version from [akarazniewicz/cocosplit](https://github.com/akarazniewicz/cocosplit)  original repo, where the functionality of splitting multi-class data while preserving distributions is added.
+The code is an updated version from [akarazniewicz/cocosplit](https://github.com/akarazniewicz/cocosplit) original repo, where the functionality of splitting multi-class data while preserving distributions is added.
 
 
 ## Installation
@@ -46,5 +46,6 @@ optional arguments:
 $ python cocosplit.py --having-annotations --multi-class -s 0.8 /path/to/your/coco_annotations.json train.json test.json
 ```
 
-will split ``coco_annotation.json`` into ``train.json`` and ``test.json`` with ratio 80%/20% respectively. It will skip all
-images (``--having-annotations``) without annotations.
+will split ``coco_annotation.json`` into ``train.json`` and ``test.json`` with ratio 80%/20% respectively. It will skip all images (``--having-annotations``) without annotations.
+
+The order of the COCO sections are: images, annotations, categories, info and licenses. In the case the original COCO file doesn't have info nor licenses, it will just skip them.

--- a/cocosplit.py
+++ b/cocosplit.py
@@ -6,10 +6,10 @@ from skmultilearn.model_selection import iterative_train_test_split
 import numpy as np
 
 
-def save_coco(file, info, licenses, images, annotations, categories):
+def save_coco(file, images, annotations, categories, info=None, licenses=None):
     with open(file, 'wt', encoding='UTF-8') as coco:
-        json.dump({ 'info': info, 'licenses': licenses, 'images': images, 
-            'annotations': annotations, 'categories': categories}, coco, indent=2, sort_keys=True)
+        json.dump({'images': images, 'annotations': annotations, 'categories': categories,
+                   'info': info, 'licenses': licenses}, coco, indent=2, sort_keys=True)
 
 def filter_annotations(annotations, images):
     image_ids = funcy.lmap(lambda i: int(i['id']), images)
@@ -35,6 +35,7 @@ parser.add_argument('--having-annotations', dest='having_annotations', action='s
 
 parser.add_argument('--multi-class', dest='multi_class', action='store_true',
                     help='Split a multi-class dataset while preserving class distributions in train and test sets')
+# parser.add_argument('--seq-id', dest='seq_id', action='store_true',help='Consider seq_id for grouping images into subsets')
 
 args = parser.parse_args()
 
@@ -42,8 +43,17 @@ def main(args):
 
     with open(args.annotations, 'rt', encoding='UTF-8') as annotations:
         coco = json.load(annotations)
-        info = coco['info']
-        licenses = coco['licenses']
+        # Check if 'info' and 'licenses' keys exist in the COCO annotations
+        if 'info' in coco:
+            info = coco['info']
+        else:
+            info = None
+        
+        if 'licenses' in coco:
+            licenses = coco['licenses']
+        else:
+            licenses = None
+            
         images = coco['images']
         annotations = coco['annotations']
         categories = coco['categories']
@@ -73,7 +83,7 @@ def main(args):
             save_coco(args.test, info, licenses,  filter_images(images, X_test.reshape(-1)), X_test.reshape(-1).tolist(), categories)
 
             print("Saved {} entries in {} and {} in {}".format(len(X_train), args.train, len(X_test), args.test))
-            
+
         else:
 
             X_train, X_test = train_test_split(images, train_size=args.split)

--- a/cocosplit.py
+++ b/cocosplit.py
@@ -6,10 +6,20 @@ from skmultilearn.model_selection import iterative_train_test_split
 import numpy as np
 
 
-def save_coco(file, images, annotations, categories, info=None, licenses=None):
+def save_coco(file, info, licenses, images, annotations, categories):
     with open(file, 'wt', encoding='UTF-8') as coco:
-        json.dump({'images': images, 'annotations': annotations, 'categories': categories,
-                   'info': info, 'licenses': licenses}, coco, indent=2, sort_keys=True)
+        if info and licenses:
+            json.dump({ 'images': images, 'annotations': annotations, 'categories': categories, 
+                    'info': info, 'licenses': licenses}, coco, indent=2, sort_keys=False)
+        elif info:
+            json.dump({ 'images': images, 'annotations': annotations, 'categories': categories, 
+                    'info': info}, coco, indent=2, sort_keys=False)
+        elif licenses:
+            json.dump({ 'images': images, 'annotations': annotations, 'categories': categories, 
+                    'licenses': licenses}, coco, indent=2, sort_keys=False)
+        else:
+            json.dump({ 'images': images, 'annotations': annotations, 'categories': categories}, 
+                      coco, indent=2, sort_keys=False)
 
 def filter_annotations(annotations, images):
     image_ids = funcy.lmap(lambda i: int(i['id']), images)


### PR DESCRIPTION
COCO files can have the sections 'info' and 'licenses' but, for example, it was not my case, I added a check of their existence, if they are not existing then they will be empty and not added to the test and train COCO files generated.

Before this update, it was giving an error when a COCO file without those sections wanted to be splitted.

Also, the order has been changed, it's just because I prefer the order: images - annotations - categories - [info - licenses], before this update the sections were sorted alphabetically. 